### PR TITLE
Correcting an issue with the client-server call-back in the main loop

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -28,29 +28,30 @@ end
 
 -- Thread to handle the fuel consumption
 function createFuelConsumptionThread()
-	CreateThread(function()
-		local currentVehiclePlate = nil
-		local currentVehicleFuelType = "default" -- default while the callback loads
-		DecorRegister(fuelDecor, 1)
-		while true do
-			Wait(1000)
-			local ped = PlayerPedId()
-			if IsPedInAnyVehicle(ped, false) then
-				local vehicle = GetVehiclePedIsIn(ped, false)
-				if GetPedInVehicleSeat(vehicle, -1) == ped and not IsVehicleBlacklisted(vehicle) then
-					if currentVehiclePlate == nil then
-						currentVehiclePlate = GetVehicleNumberPlateText(vehicle)
-						currentVehicleFuelType = getVehicleFuelTypeFromServer(vehicle)
-					end
-					HandleFuelConsumption(vehicle, currentVehicleFuelType)
-				end
-			else
-				currentVehicleFuelType = "default"
-				currentVehiclePlate = nil
-				fuelSynced = false
-			end
-		end
-	end)
+    CreateThread(function()
+        local currentVehicle = nil
+        local currentVehicleFuelType = "default" -- default while the callback loads
+        DecorRegister(fuelDecor, 1)
+        while true do
+            Wait(1000)
+            local ped = PlayerPedId()
+            if IsPedInAnyVehicle(ped, false) then
+                local vehicle = GetVehiclePedIsIn(ped, false)
+                if GetPedInVehicleSeat(vehicle, -1) == ped and not IsVehicleBlacklisted(vehicle) then
+                    if currentVehicle == nil or currentVehicle ~= vehicle then
+                        currentVehicle = vehicle
+                        currentVehicleFuelType = getVehicleFuelTypeFromServer(vehicle)
+                        fuelSynced = false
+                    end
+                    HandleFuelConsumption(vehicle, currentVehicleFuelType)
+                end
+            else
+                currentVehicleFuelType = "default"
+                currentVehicle = nil
+                fuelSynced = false
+            end
+        end
+    end)
 end
 
 function HandleFuelConsumption(vehicle, fuelType)

--- a/client/client.lua
+++ b/client/client.lua
@@ -39,6 +39,7 @@ function createFuelConsumptionThread()
 				local vehicle = GetVehiclePedIsIn(ped, false)
 				if GetPedInVehicleSeat(vehicle, -1) == ped and not IsVehicleBlacklisted(vehicle) then
 					if currentVehiclePlate == nil then
+						currentVehiclePlate = GetVehicleNumberPlateText(vehicle)
 						currentVehicleFuelType = getVehicleFuelTypeFromServer(vehicle)
 					end
 					HandleFuelConsumption(vehicle, currentVehicleFuelType)


### PR DESCRIPTION
Inside the main client loop the logic tries to lazily initialize the fuel type variable but it derives the lazy status from the plate number string. The plate number string is never set and therefore the fuel type server call is triggered every loop. 

Correcting this variable initialization ensures that the server call-back is only triggered once and reduces load on the server significantly (from the scripts perspective).

Alternatively, the `currentVehiclePlate` variable could be removed and replaced with `currentVehicleFuelType` inside the IF condition and usages of `currentVehiclePlate` replaced with this variable instead. This is due to the fact that the `currentVehiclePlate` variable is not used in this function.