### PR TITLE
fix(client): sync jerry can ammo with ox_inventory metadata

### DIFF
--- a/client/client_gas.lua
+++ b/client/client_gas.lua
@@ -128,6 +128,17 @@ AddEventHandler('qb-weapons:client:SetCurrentWeapon', function(data, bool)
     end
 end)
 
+AddEventHandler('ox_inventory:currentWeapon', function(weapon)
+    if weapon then
+        if weapon.metadata then
+            weapon.info = weapon.metadata
+        end
+        currentWeaponData = weapon
+    else
+        currentWeaponData = {}
+    end
+end)
+
 -- Get jerry can ammo by metadata
 function getJerryCanAmmo()
     if currentWeaponData and currentWeaponData.info and currentWeaponData.info.ammo then


### PR DESCRIPTION
- Context  
  With ox_inventory, ammo may live under weapon.metadata.ammo instead of weapon.info.ammo, which can cause jerry can ammo to desync during refueling or after weapon switches.

- What’s Changed  
  - Listen to ox_inventory:currentWeapon.  
  - If weapon.metadata exists, map it to weapon.info to normalize the data source.  
  - Keep currentWeaponData updated so getJerryCanAmmo reads the correct ammo value.

- Why  
  Prevent ammo desync for the jerry can in ox_inventory environments.

- Compatibility  
  Backward-compatible: only maps metadata to info when metadata exists; otherwise behavior remains unchanged.

- Testing  
  - With ox_inventory: ammo stays in sync while refueling and after switching weapons.  
  - Without ox_inventory: no behavior change observed.

- Files Changed  
  `client/client_gas.lua`